### PR TITLE
Result improvements

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -93,7 +93,7 @@ final class CreateUserHandler implements IHandler
         $user = new User($command->email);
         $this->em->persist($user);
 
-        return DataResult::of($user);
+        return DataResult::from($user);
     }
 
 }

--- a/src/CommandBus.php
+++ b/src/CommandBus.php
@@ -50,7 +50,7 @@ class CommandBus
 
 		// No result, thus create result manually
 		if ($return === null) {
-			return NullResult::of();
+			return new NullResult();
 		}
 
 		return $return;

--- a/src/Result/DataResult.php
+++ b/src/Result/DataResult.php
@@ -10,12 +10,12 @@ class DataResult extends Result
 
 	protected mixed $data;
 
-	protected function __construct(mixed $data)
+	public function __construct(mixed $data)
 	{
 		$this->data = $data;
 	}
 
-	public static function of(mixed $data): self
+	public static function from(mixed $data): self
 	{
 		return new static($data);
 	}
@@ -23,37 +23,37 @@ class DataResult extends Result
 	/**
 	 * @param mixed[] $data
 	 */
-	public static function ofArray(array $data): self
+	public static function fromArray(array $data): self
 	{
 		return new static($data);
 	}
 
-	public static function ofNull(): self
+	public static function fromNull(): self
 	{
 		return new static(null);
 	}
 
-	public static function ofScalar(string|int|float|bool $data): self
+	public static function fromScalar(string|int|float|bool $data): self
 	{
 		return new static($data);
 	}
 
-	public static function ofString(string $data): self
+	public static function fromString(string $data): self
 	{
 		return new static($data);
 	}
 
-	public static function ofBoolean(bool $data): self
+	public static function fromBoolean(bool $data): self
 	{
 		return new static($data);
 	}
 
-	public static function ofInteger(int $data): self
+	public static function fromInteger(int $data): self
 	{
 		return new static($data);
 	}
 
-	public static function ofStructure(\stdClass $data): self
+	public static function fromStructure(\stdClass $data): self
 	{
 		return new static($data);
 	}

--- a/src/Result/EmptyResult.php
+++ b/src/Result/EmptyResult.php
@@ -8,14 +8,4 @@ namespace Contributte\Bus\Result;
 class EmptyResult extends Result
 {
 
-	protected function __construct()
-	{
-		// Secure constructor
-	}
-
-	public static function of(): self
-	{
-		return new static();
-	}
-
 }

--- a/src/Result/NullResult.php
+++ b/src/Result/NullResult.php
@@ -11,16 +11,6 @@ use Contributte\Bus\Exception\LogicException;
 class NullResult extends Result
 {
 
-	protected function __construct()
-	{
-		// Secure constructor
-	}
-
-	public static function of(): self
-	{
-		return new static();
-	}
-
 	public function trackEvent(Event $event): Event
 	{
 		throw new LogicException('Events not implement');

--- a/src/Utils/Functions.php
+++ b/src/Utils/Functions.php
@@ -17,7 +17,7 @@ final class Functions
 
 	public static function leaf(): callable
 	{
-		return fn (): Result => EmptyResult::of();
+		return fn (): Result => new EmptyResult();
 	}
 
 }

--- a/tests/Cases/Middleware/HandlerMiddlewareTest.php
+++ b/tests/Cases/Middleware/HandlerMiddlewareTest.php
@@ -20,7 +20,7 @@ Toolkit::test(function (): void {
 	$handler = $locator = Mockery::mock(IHandler::class);
 	$locator->shouldReceive('handle')
 		->once()
-		->andReturn(DataResult::ofScalar(true));
+		->andReturn(DataResult::fromScalar(true));
 
 	$locator = Mockery::mock(IHandlerLocator::class);
 	$locator->shouldReceive('find')

--- a/tests/Cases/Result/DataResultTest.php
+++ b/tests/Cases/Result/DataResultTest.php
@@ -6,44 +6,51 @@ use Tester\Assert;
 
 require_once __DIR__ . '/../../bootstrap.php';
 
+// Getting data (mixed)
+Toolkit::test(function (): void {
+	$result = DataResult::from(123456);
+
+	Assert::equal(123456, $result->getData());
+});
+
 // Getting data (null)
 Toolkit::test(function (): void {
-	$result = DataResult::ofNull();
+	$result = DataResult::fromNull();
 
 	Assert::equal(null, $result->getData());
 });
 
 // Getting data (boolean)
 Toolkit::test(function (): void {
-	$result = DataResult::ofBoolean(false);
+	$result = DataResult::fromBoolean(false);
 
 	Assert::equal(false, $result->getData());
 });
 
 // Getting data (array)
 Toolkit::test(function (): void {
-	$result = DataResult::ofArray([]);
+	$result = DataResult::fromArray([]);
 
 	Assert::equal([], $result->getData());
 });
 
 // Getting data (scalar)
 Toolkit::test(function (): void {
-	$result = DataResult::ofScalar(123456);
+	$result = DataResult::fromScalar(123456);
 
 	Assert::equal(123456, $result->getData());
 });
 
 // Getting data (integer)
 Toolkit::test(function (): void {
-	$result = DataResult::ofInteger(123456);
+	$result = DataResult::fromInteger(123456);
 
 	Assert::equal(123456, $result->getData());
 });
 
 // Getting data (string)
 Toolkit::test(function (): void {
-	$result = DataResult::ofString('123456');
+	$result = DataResult::fromString('123456');
 
 	Assert::equal('123456', $result->getData());
 });
@@ -52,7 +59,7 @@ Toolkit::test(function (): void {
 Toolkit::test(function (): void {
 	$struct = (object) ['foo' => 'bar'];
 
-	$result = DataResult::ofStructure($struct);
+	$result = DataResult::fromStructure($struct);
 
 	Assert::equal($struct, $result->getData());
 });

--- a/tests/Cases/Result/EmptyResultTest.php
+++ b/tests/Cases/Result/EmptyResultTest.php
@@ -7,6 +7,6 @@ use Tester\Assert;
 require_once __DIR__ . '/../../bootstrap.php';
 
 Toolkit::test(function (): void {
-	$result = EmptyResult::of();
+	$result = new EmptyResult();
 	Assert::equal([], $result->pullEvents());
 });

--- a/tests/Cases/Result/NullResultTest.php
+++ b/tests/Cases/Result/NullResultTest.php
@@ -7,7 +7,7 @@ use Tester\Assert;
 require_once __DIR__ . '/../../bootstrap.php';
 
 Toolkit::test(function (): void {
-	$result = NullResult::of();
+	$result = new NullResult();
 
 	Assert::exception(
 		fn () => $result->pullEvents(),

--- a/tests/Fixtures/DummyHandler.php
+++ b/tests/Fixtures/DummyHandler.php
@@ -12,7 +12,7 @@ final class DummyHandler implements IHandler
 
 	public function handle(Command $command): Result
 	{
-		return EmptyResult::of();
+		return new EmptyResult();
 	}
 
 }


### PR DESCRIPTION
I propose several improvements for Result classes:

- All Results' constructors made public
- Removed `of` static method
- Renamed `of<something>` static methods to `from<something>`

This way it seems more readable to me.