### PR TITLE
Use php in coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tests:
 .PHONY: coverage
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary
- replace `-p phpdbg` with `-p php` in the `coverage` target
- keep local and GitHub Actions coverage commands aligned with the org-wide migration tracked in contributte/contributte#73

## Motivation
This repository still used `phpdbg` for coverage runs. The broader migration switches coverage execution to plain `php`, so this updates the local Makefile target to match that direction.

## Changes
- update both `coverage` target branches in `Makefile` to use `php`
- verify the resolved command with `make -n coverage`

## Testing
- [x] `make -n coverage`
- [ ] CI passes
- [ ] Manual verification